### PR TITLE
Make scanning process cleaner

### DIFF
--- a/sbm2mqtt.py
+++ b/sbm2mqtt.py
@@ -37,7 +37,7 @@ class ScanDelegate(DefaultDelegate):
         # Check for model "T" (54) in 16b service data
         if (
             services and services[0] == service_uuid
-            and service_data and len(service_data) == 8 and service_data[2] == b"T"
+            and service_data and len(service_data) == 8 and service_data[2] == 0x54
         ):
             mac = dev.addr
             binvalue = service_data

--- a/sbm2mqtt.py
+++ b/sbm2mqtt.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
@@ -9,9 +8,8 @@
 #   https://github.com/bbostock/Switchbot_Py_Meter
 #   https://qiita.com/warpzone/items/11ec9bef21f5b965bce3.
 
-from bluepy.btle import Scanner, DefaultDelegate
+from bluepy.btle import Scanner, DefaultDelegate, ScanEntry
 import datetime
-import binascii
 import paho.mqtt.client as mqtt
  
 # Import configuration variables from sbm2mqtt_config.py file - Must be in the same folder as this script
@@ -30,76 +28,71 @@ service_uuid = "cba20d00-224d-11e6-9fb8-0002a5d5c51b"
 
 
 class ScanDelegate(DefaultDelegate):
-    def __init__(self):
-        DefaultDelegate.__init__(self)
-
     # Scan for BLE device advertisements, filter out ones which are not SwitchBot Meters & convert the service data to binary
     def handleDiscovery(self, dev, isNewDev, isNewData):
-        for (adtype, desc, value) in dev.getScanData():
-            if (
-                adtype == 7 and value == service_uuid
-            ):  # Check for devices with Switchnot devices
-                mac = dev.addr
-                for (adtype, desc, value) in dev.getScanData():
-                    if (
-                        len(value) == 16 and value[4:6] == "54"
-                    ):  # Check for model "T" (54) in 16b service data
-                        binvalue = binascii.unhexlify(
-                            value
-                        )  # Convert service data from hex to binary; See BLE API docs and warpzone link above for value mapping
+        services = dev.getValue(ScanEntry.COMPLETE_128B_SERVICES)
+        service_data = dev.getValue(ScanEntry.SERVICE_DATA_16B)
 
-                        # Get temperature and related characteristics
-                        temperature = (binvalue[6] & 0b01111111) + (
-                            (binvalue[5] & 0b00001111) / 10
-                        )  # Absolute value of temp
-                        if not (binvalue[6] & 0b10000000):  # Is temp negative?
-                            temperature = -temperature
-                        if not (binvalue[7] & 0b10000000):  # C or F?
-                            temp_scale = "C"
-                        else:
-                            temp_scale = "F"
-                            temperature = round(
-                                temperature * 1.8 + 32, 1
-                            )  # Convert to F
+        # Check for model "T" (54) in 16b service data
+        if (
+            services and services[0] == service_uuid
+            and service_data and len(service_data) == 8 and service_data[2] == b"T"
+        ):
+            mac = dev.addr
+            binvalue = service_data
 
-                        # Get other info
-                        humidity = binvalue[7] & 0b01111111
-                        battery = binvalue[4] & 0b01111111
+            # Get temperature and related characteristics
+            temperature = (binvalue[6] & 0b01111111) + (
+                (binvalue[5] & 0b00001111) / 10
+            )  # Absolute value of temp
+            if not (binvalue[6] & 0b10000000):  # Is temp negative?
+                temperature = -temperature
+            if not (binvalue[7] & 0b10000000):  # C or F?
+                temp_scale = "C"
+            else:
+                temp_scale = "F"
+                temperature = round(
+                    temperature * 1.8 + 32, 1
+                )  # Convert to F
 
-                        # Get current time
-                        time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            # Get other info
+            humidity = binvalue[7] & 0b01111111
+            battery = binvalue[4] & 0b01111111
 
-                        # Print info to terminal
-                        print("\n" + mac + " @ " + str(time))
-                        print("  Temp: " + str(temperature) + "\u00B0" + temp_scale)
-                        print("  Humidity: " + str(humidity) + "%")
-                        print("  Battery: " + str(battery) + "%")
+            # Get current time
+            time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
-                        # MQTT publish as JSON
-                        msg_data = (
-                            '{"time":"'
-                            + time
-                            + '","temperature":'
-                            + str(temperature)
-                            + ',"humidity":'
-                            + str(humidity)
-                            + ',"battery":'
-                            + str(battery)
-                            + ',"temperature_scale":"'
-                            + temp_scale
-                            + '"}'
-                        )
-                        print(
-                            "\n  Publishing MQTT payload to "
-                            + mqtt_topic
-                            + mac
-                            + " ...\n\n    "
-                            + msg_data
-                        )
-                        mqttc = mqtt.Client(mqtt_client)
-                        mqttc.username_pw_set(mqtt_user, mqtt_pass)
-                        mqttc.connect(mqtt_host, mqtt_port)
-                        mqttc.publish(mqtt_topic + mac, msg_data, 1)
+            # Print info to terminal
+            print("\n" + mac + " @ " + str(time))
+            print("  Temp: " + str(temperature) + "\u00B0" + temp_scale)
+            print("  Humidity: " + str(humidity) + "%")
+            print("  Battery: " + str(battery) + "%")
+
+            # MQTT publish as JSON
+            msg_data = (
+                '{"time":"'
+                + time
+                + '","temperature":'
+                + str(temperature)
+                + ',"humidity":'
+                + str(humidity)
+                + ',"battery":'
+                + str(battery)
+                + ',"temperature_scale":"'
+                + temp_scale
+                + '"}'
+            )
+            print(
+                "\n  Publishing MQTT payload to "
+                + mqtt_topic
+                + mac
+                + " ...\n\n    "
+                + msg_data
+            )
+            mqttc = mqtt.Client(mqtt_client)
+            mqttc.username_pw_set(mqtt_user, mqtt_pass)
+            mqttc.connect(mqtt_host, mqtt_port)
+            mqttc.publish(mqtt_topic + mac, msg_data, 1)
 
 
 def main():

--- a/sbm2mqtt.py
+++ b/sbm2mqtt.py
@@ -11,7 +11,8 @@
 from bluepy.btle import Scanner, DefaultDelegate, ScanEntry
 import datetime
 import paho.mqtt.client as mqtt
- 
+import json
+
 # Import configuration variables from sbm2mqtt_config.py file - Must be in the same folder as this script
 from sbm2mqtt_config import (
     mqtt_host,
@@ -69,19 +70,14 @@ class ScanDelegate(DefaultDelegate):
             print("  Battery: " + str(battery) + "%")
 
             # MQTT publish as JSON
-            msg_data = (
-                '{"time":"'
-                + time
-                + '","temperature":'
-                + str(temperature)
-                + ',"humidity":'
-                + str(humidity)
-                + ',"battery":'
-                + str(battery)
-                + ',"temperature_scale":"'
-                + temp_scale
-                + '"}'
-            )
+            msg_data = json.dumps({
+                "time": time,
+                "temperature": temperature,
+                "humidity": humidity,
+                "battery": battery,
+                "temperature_scale": temp_scale,
+                "signal_strength": dev.rssi,
+            })
             print(
                 "\n  Publishing MQTT payload to "
                 + mqtt_topic


### PR DESCRIPTION
Trying to get my switchbot sensor connected to my Home Assistant network, this project is looking very useful, thank you :)

This PR is not intended to have any behaviour changes - it should just do the same thing more efficiently, as it replaces two nested loops with two dictionary lookups, and removes a `binary -> text -> binary` conversion

Old approach:
- scan through all the results checking for something which looks like a service UUID
- check if the service UUID matches
- if it matches, then check through all the results a second time, looking for anything that looks like service data
- if we find service data
- then take the text form of the data, and convert it to binary
- parse the binary

New approach:
- check service UUID directly
- check service data directly
- parse the binary