### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
 # docker build . -t sbm2mqtt
-# docker run --rm --net=host --privileged -it sbm2mqtt
+# docker run --rm --net=host --privileged -it -e MQTT_HOST=192.168.1.10 -e MQTT_USER=bob -e MQTT_PASS=waffles sbm2mqtt
 FROM python:3.7
 RUN apt-get update && apt-get install -y bluez bluetooth
 RUN pip install bluepy paho-mqtt
+ENV \
+    MQTT_HOST=127.0.0.1 \
+    MQTT_PORT=1883 \
+    MQTT_USER=xxxxxx \
+    MQTT_PASS=xxxxxx \
+    MQTT_INTERVAL=300
 ENTRYPOINT sh docker_entrypoint.sh
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+# docker build . -t sbm2mqtt
+# docker run --rm --net=host --privileged -it sbm2mqtt
+FROM python:3.7
+RUN apt-get update && apt-get install -y bluez bluetooth
+RUN pip install bluepy paho-mqtt
+ENTRYPOINT sh docker_entrypoint.sh
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # docker build . -t sbm2mqtt
-# docker run --rm --net=host --privileged -it -e MQTT_HOST=192.168.1.10 -e MQTT_USER=bob -e MQTT_PASS=waffles sbm2mqtt
+# docker run --rm --net=host --privileged -it -e MQTT_HOST=xxx.xxx.xxx.xxx -e MQTT_PORT=xxxx -e MQTT_USER=xxxxxx -e MQTT_PASS=xxxxxx sbm2mqtt
 FROM python:3.7
 RUN apt-get update && apt-get install -y bluez bluetooth
 RUN pip install bluepy paho-mqtt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ENV \
     MQTT_PORT=1883 \
     MQTT_USER=xxxxxx \
     MQTT_PASS=xxxxxx \
-    MQTT_INTERVAL=300
+    MQTT_CLIENT=sbm2mqtt \
+    MQTT_TOPIC=switchbot_meter \
+    REPORTING_INTERVAL=300
+      # in seconds
 ENTRYPOINT sh docker_entrypoint.sh
 COPY . .

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -5,5 +5,5 @@ bluetoothd &
 
 while true ; do
 	./sbm2mqtt.py
-	sleep $MQTT_INTERVAL || break
+	sleep $REPORTING_INTERVAL || break
 done

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -3,4 +3,7 @@
 service dbus start
 bluetoothd &
 
-./sbm2mqtt.py
+while true ; do
+	./sbm2mqtt.py
+	sleep $MQTT_INTERVAL || break
+done

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+service dbus start
+bluetoothd &
+
+./sbm2mqtt.py

--- a/sbm2mqtt_config.py
+++ b/sbm2mqtt_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 # Use environement variables or replace with your own values
+# Environment variables override contents of this file
 # Place in same folder as sbm2mqtt.py
 
 import os
@@ -9,7 +10,7 @@ import os
 mqtt_host = os.environ.get("MQTT_HOST", "127.0.0.1")
 mqtt_port = int(os.environ.get("MQTT_PORT", "1883"))
 mqtt_timeout = int(os.environ.get("MQTT_TIMEOUT", "30"))
-mqtt_client = os.environ.get("MQTT_CLIENT", "switchbot_meter_checker")
+mqtt_client = os.environ.get("MQTT_CLIENT", "sbm2mqtt")
 mqtt_user = os.environ.get("MQTT_USER", "xxxxxx")
 mqtt_pass = os.environ.get("MQTT_PASS", "xxxxxx")
-mqtt_topic = os.environ.get("MQTT_TOPIC", "switchbot_meter/")
+mqtt_topic = os.environ.get("MQTT_TOPIC", "switchbot_meter")

--- a/sbm2mqtt_config.py
+++ b/sbm2mqtt_config.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
-# Replace with your own values
+# Use environement variables or replace with your own values
 # Place in same folder as sbm2mqtt.py
 
+import os
+
 # MQTT settings
-mqtt_host = "xxx.xxx.xxx.xxx"
-mqtt_port = xxxx
-mqtt_timeout = 30
-mqtt_client = "switchbot_meter_checker"
-mqtt_user = "xxxxxx"
-mqtt_pass = "xxxxxx"
-mqtt_topic = "switchbot_meter/"
+mqtt_host = os.environ.get("MQTT_HOST", "127.0.0.1")
+mqtt_port = int(os.environ.get("MQTT_PORT", "1883"))
+mqtt_timeout = int(os.environ.get("MQTT_TIMEOUT", "30"))
+mqtt_client = os.environ.get("MQTT_CLIENT", "switchbot_meter_checker")
+mqtt_user = os.environ.get("MQTT_USER", "xxxxxx")
+mqtt_pass = os.environ.get("MQTT_PASS", "xxxxxx")
+mqtt_topic = os.environ.get("MQTT_TOPIC", "switchbot_meter/")


### PR DESCRIPTION
Because I want to keep my home server's bare-metal OS as clean as possible, and keep the bluetooth / python development stuff self-contained

I'm also considering using environment variables rather than a config file, so that one can use a pre-built docker image configured at runtime, instead of needing to re-build the image each time the config file is changed

Also the docker_entrypoint.sh stuff could be nicer too...

I'm submitting this pull request as-is just to get feedback on whether you like the idea or not. If you like the idea then I'll go to the extra effort of making it tidy before it gets merged :)